### PR TITLE
Master v2

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,31 +1,41 @@
 FROM ubuntu:14.04
 
-RUN sudo apt-get -y update
-RUN apt-get install -y g++ autoconf qt4-dev-tools patch libtool make git
-RUN apt-get install -y software-properties-common python-software-properties
+# Step 1: set up a sane build system
+USER root
 
-# fix to get cmake 3.x in ubuntu 14.04
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests g++ autoconf automake patch libtool make git
+RUN apt-get install -y --no-install-recommends --no-install-suggests software-properties-common python-software-properties
+
+# Step 2: get an up-to date cmake 3.x for ubuntu 14.04
 RUN add-apt-repository ppa:george-edison55/cmake-3.x
-RUN sudo apt-get remove -y cmake cmake-data
-RUN sudo -E apt-get update
+RUN apt-get -y update
 RUN apt-get install -y cmake
 
-# install dependencies
-RUN apt-get install -qq libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev
-RUN apt-get install -qq libboost-date-time1.54-dev \
-                        libboost-iostreams1.54-dev \
-                        libboost-regex1.54-dev \
-                        libboost-math1.54-dev \
-                        libboost-random1.54-dev
+# Step 3: advanced dependencies
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.54-dev \
+                                                                     libboost-iostreams1.54-dev \
+                                                                     libboost-regex1.54-dev \
+                                                                     libboost-math1.54-dev \
+                                                                     libboost-random1.54-dev
 
+# Step 4: install Qt4
+RUN apt-get install -y --no-install-recommends --no-install-suggests qt4-dev-tools qt4-default qt4-qtconfig qt4-qmake
+RUN apt-get install -y --no-install-recommends --no-install-suggests libqt4-dev libqt4-opengl-dev libqt4-svg libqtwebkit-dev
 
-RUN git clone https://github.com/OpenMS/contrib.git
+###################################
+# Step 5: Compiled dependencies
+RUN git clone https://github.com/OpenMS/contrib.git && rm -rf contrib/.git/
 RUN mkdir contrib-build
 
 WORKDIR /contrib-build
 
-RUN cmake -DBUILD_TYPE=SEQAN ../contrib
-RUN cmake -DBUILD_TYPE=WILDMAGIC ../contrib
-RUN cmake -DBUILD_TYPE=EIGEN ../contrib
-RUN cmake -DBUILD_TYPE=COINOR ../contrib
-RUN cmake -DBUILD_TYPE=SQLITE ../contrib
+RUN cmake -DBUILD_TYPE=SEQAN ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=WILDMAGIC ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=EIGEN ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=COINOR ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=SQLITE ../contrib && rm -rf archives src
+
+WORKDIR /
+

--- a/contrib/Dockerfile-qt5
+++ b/contrib/Dockerfile-qt5
@@ -1,32 +1,41 @@
 FROM ubuntu:14.04
 
-RUN sudo apt-get -y update
-RUN apt-get install -y g++ autoconf patch libtool make git
-RUN apt-get install -y software-properties-common python-software-properties
+# Step 1: set up a sane build system
+USER root
 
-# fix to get cmake 3.x in ubuntu 14.04
-RUN add-apt-repository -y ppa:george-edison55/cmake-3.x
-RUN add-apt-repository -y ppa:beineri/opt-qt571-trusty
-RUN sudo apt-get remove -y cmake cmake-data
-RUN sudo -E apt-get update
-RUN apt-get install -y cmake qt57-meta-full
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests g++ autoconf automake patch libtool make git
+RUN apt-get install -y --no-install-recommends --no-install-suggests software-properties-common python-software-properties
 
-# install dependencies
-RUN apt-get install -qq libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev
-RUN apt-get install -qq libboost-date-time1.54-dev \
-                        libboost-iostreams1.54-dev \
-                        libboost-regex1.54-dev \
-                        libboost-math1.54-dev \
-                        libboost-random1.54-dev
+# Step 2: obtain cmake 3.x in ubuntu 14.04
+RUN add-apt-repository ppa:george-edison55/cmake-3.x
+RUN apt-get -y update
+RUN apt-get install -y cmake
 
+# Step 3: advanced dependencies
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.54-dev \
+                                                                     libboost-iostreams1.54-dev \
+                                                                     libboost-regex1.54-dev \
+                                                                     libboost-math1.54-dev \
+                                                                     libboost-random1.54-dev
+# Step 4: Qt5
+RUN add-apt-repository ppa:beineri/opt-qt571-trusty 
+RUN apt-get -y update
+RUN apt-get install -y qt57base qt57webengine qt57svg libgl1-mesa-dev
 
-RUN git clone https://github.com/OpenMS/contrib.git
+###################################
+# Step 5: Compiled dependencies
+RUN git clone https://github.com/OpenMS/contrib.git && rm -rf contrib/.git/
 RUN mkdir contrib-build
 
 WORKDIR /contrib-build
 
-RUN cmake -DBUILD_TYPE=SEQAN ../contrib
-RUN cmake -DBUILD_TYPE=WILDMAGIC ../contrib
-RUN cmake -DBUILD_TYPE=EIGEN ../contrib
-RUN cmake -DBUILD_TYPE=COINOR ../contrib
-RUN cmake -DBUILD_TYPE=SQLITE ../contrib
+RUN cmake -DBUILD_TYPE=SEQAN ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=WILDMAGIC ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=EIGEN ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=COINOR ../contrib && rm -rf archives src
+RUN cmake -DBUILD_TYPE=SQLITE ../contrib && rm -rf archives src
+
+WORKDIR /
+

--- a/executables/Dockerfile
+++ b/executables/Dockerfile
@@ -2,5 +2,8 @@ FROM openms/library
 
 WORKDIR /openms-build
 
-RUN make TOPP 
-RUN make UTILS
+RUN make TOPP && make UTILS && rm -rf src doc CMakeFiles 
+
+WORKDIR /
+ENV PATH="/openms-build/bin/:${PATH}"
+

--- a/library/Dockerfile-qt5
+++ b/library/Dockerfile-qt5
@@ -1,0 +1,14 @@
+FROM openms/contrib:qt5-v2.0
+
+WORKDIR /
+RUN git clone https://github.com/OpenMS/OpenMS.git && cd /OpenMS && git checkout feature/qt5 && rm -rf .git share/OpenMS/examples/
+
+RUN mkdir openms-build
+WORKDIR /openms-build
+
+# Load the Qt5 environment and configure
+RUN QT_ENV=$(find /opt -name 'qt*-env.sh') && /bin/bash -c "source ${QT_ENV} && cmake -DCMAKE_PREFIX_PATH='/contrib-build/;/usr/;/usr/local' -DBOOST_USE_STATIC=OFF ../OpenMS"
+
+# make OpenMS library
+RUN make OpenMS -j6
+


### PR DESCRIPTION
updated Docker files (version 2.0) - they are substantially smaller and more clearly organized, contain better comments and both structured hierarchically

- see https://hub.docker.com/r/openms/contrib/tags/ for a comparison of size:

```
v2.0: 332 MB
latest: 538 MB
qt5: 837 MB
qt5-v2.0: 437 MB
```

I configured and built the OpenMS library for both of them, the containers work.