### PR TITLE
Bleeding

### DIFF
--- a/contrib/Dockerfile-sid-clang4
+++ b/contrib/Dockerfile-sid-clang4
@@ -1,0 +1,35 @@
+FROM debian:unstable
+
+# Step 1: set up a sane build system
+USER root
+
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests clang-4.0 autoconf automake patch libtool make git
+# RUN apt-get install -y --no-install-recommends --no-install-suggests software-properties-common python-software-properties
+RUN apt-get install -y --no-install-recommends --no-install-suggests software-properties-common 
+
+# Step 2: cmake (see below)
+
+# Step 3: advanced dependencies
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev cmake
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.62-dev \
+                                                                     libboost-iostreams1.62-dev \
+                                                                     libboost-regex1.62-dev \
+                                                                     libboost-math1.62-dev \
+                                                                     libboost-random1.62-dev
+
+# Step 4: install Qt4
+RUN apt-get install -y --no-install-recommends --no-install-suggests qt4-dev-tools qt4-default qt4-qtconfig qt4-qmake
+RUN apt-get install -y --no-install-recommends --no-install-suggests libqt4-dev libqt4-opengl-dev libqt4-svg libqtwebkit-dev
+
+###################################
+# Step 5: install specific dependencies (previously compiled)
+RUN apt-get install -y --no-install-recommends --no-install-suggests libwildmagic-dev \
+         coinor-libcoinutils-dev coinor-libcgl-dev coinor-libcbc-dev \
+         coinor-libclp-dev coinor-libosi-dev coinor-libvol-dev \
+         seqan-dev libeigen3-dev libsqlite3-dev
+
+# This makes the contrib package unnecessary
+
+WORKDIR /
+

--- a/contrib/Dockerfile-sid-gcc7
+++ b/contrib/Dockerfile-sid-gcc7
@@ -1,0 +1,35 @@
+FROM debian:unstable
+
+# Step 1: set up a sane build system
+USER root
+
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests g++-7 autoconf automake patch libtool make git
+# RUN apt-get install -y --no-install-recommends --no-install-suggests software-properties-common python-software-properties
+RUN apt-get install -y --no-install-recommends --no-install-suggests software-properties-common 
+
+# Step 2: cmake (see below)
+
+# Step 3: advanced dependencies
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev libglpk-dev libzip-dev zlib1g-dev libxerces-c-dev libbz2-dev cmake
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.62-dev \
+                                                                     libboost-iostreams1.62-dev \
+                                                                     libboost-regex1.62-dev \
+                                                                     libboost-math1.62-dev \
+                                                                     libboost-random1.62-dev
+
+# Step 4: install Qt4
+RUN apt-get install -y --no-install-recommends --no-install-suggests qt4-dev-tools qt4-default qt4-qtconfig qt4-qmake
+RUN apt-get install -y --no-install-recommends --no-install-suggests libqt4-dev libqt4-opengl-dev libqt4-svg libqtwebkit-dev
+
+###################################
+# Step 5: install specific dependencies (previously compiled)
+RUN apt-get install -y --no-install-recommends --no-install-suggests libwildmagic-dev \
+         coinor-libcoinutils-dev coinor-libcgl-dev coinor-libcbc-dev \
+         coinor-libclp-dev coinor-libosi-dev coinor-libvol-dev \
+         seqan-dev libeigen3-dev libsqlite3-dev
+
+# This makes the contrib package unnecessary
+
+WORKDIR /
+

--- a/library/Dockerfile-sid-clang4
+++ b/library/Dockerfile-sid-clang4
@@ -1,0 +1,15 @@
+FROM openms/contrib:sid-clang4
+
+# /usr/bin/g++-7
+# hr@hr-Precision-5520:~/docker/openms_docker/library$ sudo docker run openms/contrib:sid-gcc7 ls /usr/bin/gcc-7
+# /usr/bin/gcc-7
+
+WORKDIR /
+# RUN git clone --depth 1 https://github.com/OpenMS/OpenMS.git -b nightly
+RUN git clone https://github.com/OpenMS/OpenMS.git && cd OpenMS && git checkout fix/build_gcc
+RUN mkdir openms-build
+
+WORKDIR /openms-build
+
+RUN export CC=/usr/bin/clang-4.0 && export CXX=/usr/bin/clang++-4.0 && cmake -DOPENMS_CONTRIB_LIBS="/contrib-build" -DCMAKE_PREFIX_PATH="/usr;/usr/local" -DBOOST_USE_STATIC=OFF ../OpenMS
+RUN make OpenMS

--- a/library/Dockerfile-sid-gcc7
+++ b/library/Dockerfile-sid-gcc7
@@ -1,0 +1,11 @@
+FROM openms/contrib:sid-gcc7
+
+WORKDIR /
+# RUN git clone --depth 1 https://github.com/OpenMS/OpenMS.git -b nightly
+RUN git clone https://github.com/OpenMS/OpenMS.git && cd OpenMS && git checkout fix/build_gcc
+RUN mkdir openms-build
+
+WORKDIR /openms-build
+
+RUN export CC=/usr/bin/gcc-7 && export CXX=/usr/bin/g++-7 && cmake -DOPENMS_CONTRIB_LIBS="/contrib-build" -DCMAKE_PREFIX_PATH="/usr;/usr/local" -DBOOST_USE_STATIC=OFF ../OpenMS
+RUN make OpenMS


### PR DESCRIPTION
two docker files for gcc7.1 and clang4.0 

- still uses `git checkout fix/build_gcc` until this is merged