### PR TITLE
multistage docker builds make for slimmer images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # OpenMS Dockerfiles
 This repository holds Dockerfiles for creating docker images for several OpenMS configurations based on different base images.
+The configurations are found in self-descriptive folders for the Dockerfile:
+ * batteries-included, a multistage build for the executables, including OpenMS' thirdparty binaries and JRE
+ * contrib, basis for most images - for now only contains built libraries not available in base image OS repo
+ * executables, base executables
+ * library, the built OpenMS framework libraries (no GUI)
+ * multistage, provides executables using docker build features introduced in 17.05, makes for slimmer images
+ * pyOpenMS
+ * travis
+
 For now, they are completely unoptimized and mainly intended for internal use during continuous integration.
-For now, builds are triggered on DockerCloud whenever there is a push to contrib and whenever there is a push to our nightly branch (which 
-is, as you could have guessed, at least once a night). Triggers and scheduled jobs are on our Jenkins.
+CI builds are triggered on DockerCloud whenever there is a push to contrib and whenever there is a push to our nightly branch (which is, as you could have guessed, at least once a night). 
+Triggers and scheduled jobs are on our Jenkins.
 
 Plan for when there is a release:
 - create a new release branch release/v${VERSION}

--- a/README.md
+++ b/README.md
@@ -20,5 +20,9 @@ Plan for when there is a release:
 - check that they build
 - tag the current head of the release/v${VERSION} branch with Release${VERSION} (e.g. Release2.2.0)
 
-TODO Use dockercompose YAML scripts to correctly resolve dependencies and reduce image size by not adding tools that are no dependencies.
-https://docs.docker.com/docker-cloud/builds/advanced/#custom-build-phase-hooks
+**Note**: docker-compose.yml holds the image names as used in the Dockerfiles. These should be kept as stable as possible, at some point they will reflect the names of the docker hub image names.
+```bash
+#{sudo} docker-compose create
+#{sudo} docker-compose push
+```
+TODO build travis hooks around the YAML [https://docs.docker.com/docker-cloud/builds/advanced/#custom-build-phase-hooks]

--- a/batteries-included/Dockerfile
+++ b/batteries-included/Dockerfile
@@ -73,4 +73,9 @@ WORKDIR /
 ENV PATH="/OpenMS/bin/:${PATH}"
 ENV LD_LIBRARY_PATH="/OpenMS/lib/:${LD_LIBRARY_PATH}"
 ENV PATH /opt/thirdparty/Fido:/opt/thirdparty/LuciPHOr2:/opt/thirdparty/MSGFPlus:/opt/thirdparty/MyriMatch:/opt/thirdparty/OMSSA:/opt/thirdparty/XTandem:/opt/thirdparty/OMSSA:/opt/thirdparty/Comet:/opt/thirdparty/OMSSA:/opt/thirdparty/Percolator:/opt/thirdparty/OMSSA:/opt/thirdparty/SpectraST:${PATH}
+ENV OPENMS_DATA_PATH /OpenMS/share/OpenMS
 
+RUN useradd -u 1001 -U -d /home/OpenMSuser -m -s /bin/bash OpenMSuser
+USER OpenMSuser
+ENV HOME /home/OpenMSuser
+WORKDIR /home/OpenMSuser

--- a/batteries-included/Dockerfile
+++ b/batteries-included/Dockerfile
@@ -1,0 +1,76 @@
+FROM openms/library as library
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /openms-build
+
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests binutils subversion
+
+RUN for l in lib/*.so; do strip --strip-all $l; done
+
+RUN mkdir /opt/thirdparty && \
+    svn checkout https://github.com/OpenMS/THIRDPARTY/trunk/Linux/64bit /opt/thirdparty && \
+    rm -rf /opt/thirdparty/.svn && \
+    svn checkout https://github.com/OpenMS/THIRDPARTY/trunk/All /opt/thirdparty && \
+    rm -rf /opt/thirdparty/.svn
+
+ENV PATH /opt/thirdparty/Fido:/opt/thirdparty/LuciPHOr2:/opt/thirdparty/MSGFPlus:/opt/thirdparty/MyriMatch:/opt/thirdparty/OMSSA:/opt/thirdparty/XTandem:$PATH
+
+RUN make TOPP && make UTILS  
+
+FROM ubuntu:14.04
+ENV DEBIAN_FRONTEND noninteractive
+
+LABEL software="OpenMS batteries included"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
+LABEL base.image="ubuntu:14.04"
+
+RUN mkdir /OpenMS
+WORKDIR /OpenMS
+
+COPY --from=library /OpenMS/AUTHORS .
+COPY --from=library /OpenMS/CHANGELOG .
+COPY --from=library /OpenMS/LICENSE .
+COPY --from=library /OpenMS/README .
+COPY --from=library /OpenMS/share/OpenMS/CHEMISTRY /OpenMS/share/OpenMS/CHEMISTRY
+COPY --from=library /OpenMS/share/OpenMS/CV /OpenMS/share/OpenMS/CV
+COPY --from=library /OpenMS/share/OpenMS/MAPPING /OpenMS/share/OpenMS/MAPPING
+COPY --from=library /OpenMS/share/OpenMS/SCHEMAS /OpenMS/share/OpenMS/SCHEMAS
+COPY --from=library /OpenMS/share/OpenMS/XSL /OpenMS/share/OpenMS/XSL
+COPY --from=library /OpenMS/share/OpenMS/SCRIPTS /OpenMS/share/OpenMS/SCRIPTS
+
+COPY --from=library /openms-build/bin /OpenMS/bin
+COPY --from=library /openms-build/lib /OpenMS/lib
+
+COPY --from=library /opt/thirdparty /opt/thirdparty
+
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev \
+								      libglpk-dev \
+								      libzip-dev \
+								      zlib1g-dev \
+							              libxerces-c-dev \
+                                                                     libbz2-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.54-dev \
+                                                                     libboost-iostreams1.54-dev \
+                                                                     libboost-regex1.54-dev \
+                                                                     libboost-math1.54-dev \
+                                                                     libboost-random1.54-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libqtcore4 \
+								      libqt4-network
+RUN apt-get install -y --no-install-recommends --no-install-suggests default-jre				      
+RUN apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/{cache,log}
+
+#example input for kicking tires
+#COPY --from=library /OpenMS/share/OpenMS/examples /OpenMS/share/OpenMS/examples
+
+WORKDIR /
+ENV PATH="/OpenMS/bin/:${PATH}"
+ENV LD_LIBRARY_PATH="/OpenMS/lib/:${LD_LIBRARY_PATH}"
+ENV PATH /opt/thirdparty/Fido:/opt/thirdparty/LuciPHOr2:/opt/thirdparty/MSGFPlus:/opt/thirdparty/MyriMatch:/opt/thirdparty/OMSSA:/opt/thirdparty/XTandem:/opt/thirdparty/OMSSA:/opt/thirdparty/Comet:/opt/thirdparty/OMSSA:/opt/thirdparty/Percolator:/opt/thirdparty/OMSSA:/opt/thirdparty/SpectraST:${PATH}
+

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -1,5 +1,13 @@
 FROM ubuntu:14.04
 
+LABEL software="OpenMS contrib"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile-bleeding
+++ b/contrib/Dockerfile-bleeding
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
 LABEL base.image="ubuntu:17.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile-bleeding
+++ b/contrib/Dockerfile-bleeding
@@ -1,5 +1,13 @@
 FROM ubuntu:17.04
 
+LABEL software="OpenMS contrib"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
+LABEL base.image="ubuntu:17.04"
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile-qt5
+++ b/contrib/Dockerfile-qt5
@@ -1,5 +1,13 @@
 FROM ubuntu:14.04
 
+LABEL software="OpenMS contrib"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile-qt5
+++ b/contrib/Dockerfile-qt5
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile-sid
+++ b/contrib/Dockerfile-sid
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
 LABEL base.image="debian:unstable"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 # Step 1: set up a sane build system
 USER root
 

--- a/contrib/Dockerfile-sid
+++ b/contrib/Dockerfile-sid
@@ -1,5 +1,13 @@
 FROM debian:unstable
 
+LABEL software="OpenMS contrib"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
+LABEL base.image="debian:unstable"
+
 # Step 1: set up a sane build system
 USER root
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: '3'
+services:
+  contrib:
+    build: contrib
+    image: "openms/contrib"
+  library:
+    build: library
+    image: "openms/library"
+  executables:
+    build: executables
+    image: "openms/library"
+  multistage:
+    build: multistage
+    image: "openms/multistage"
+  batteries-included:
+    build: batteries-included
+    image: "openms/batteries-included"
+  pyopenms:
+    build: pyOpenMS
+    image: "openms/pyopenms"

--- a/executables/Dockerfile
+++ b/executables/Dockerfile
@@ -1,5 +1,13 @@
 FROM openms/library 
 
+LABEL software="OpenMS executables"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 WORKDIR /openms-build
 
 RUN make TOPP && make UTILS && rm -rf src doc CMakeFiles 

--- a/executables/Dockerfile
+++ b/executables/Dockerfile
@@ -16,4 +16,10 @@ RUN make TOPP && make UTILS && rm -rf src doc CMakeFiles
 
 WORKDIR /
 ENV PATH="/openms-build/bin/:${PATH}"
+ENV LD_LIBRARY_PATH="="/openms-build/lib/:${LD_LIBRARY_PATH}"
+ENV OPENMS_DATA_PATH /OpenMS/share/OpenMS
 
+RUN useradd -u 1001 -U -d /home/OpenMSuser -m -s /bin/bash OpenMSuser
+USER OpenMSuser
+ENV HOME /home/OpenMSuser
+WORKDIR /home/OpenMSuser

--- a/executables/Dockerfile
+++ b/executables/Dockerfile
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 WORKDIR /openms-build
 
 RUN make TOPP && make UTILS && rm -rf src doc CMakeFiles 

--- a/library/Dockerfile
+++ b/library/Dockerfile
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 WORKDIR /
 RUN git clone --depth 1 https://github.com/OpenMS/OpenMS.git -b nightly
 RUN mkdir openms-build

--- a/library/Dockerfile
+++ b/library/Dockerfile
@@ -12,9 +12,10 @@ ENV DEBIAN_FRONTEND noninteractive
 
 WORKDIR /
 RUN git clone --depth 1 https://github.com/OpenMS/OpenMS.git -b nightly
+#RUN mkdir OpenMS
 RUN mkdir openms-build
 
 WORKDIR /openms-build
 
-RUN cmake -DOPENMS_CONTRIB_LIBS="/contrib-build" -DCMAKE_PREFIX_PATH="/usr;/usr/local" -DBOOST_USE_STATIC=OFF ../OpenMS
+RUN cmake -DOPENMS_CONTRIB_LIBS="/contrib-build" -DCMAKE_PREFIX_PATH="/usr;/usr/local" -DBOOST_USE_STATIC=OFF -DWITH_GUI=OFF /OpenMS
 RUN make OpenMS

--- a/library/Dockerfile
+++ b/library/Dockerfile
@@ -1,5 +1,13 @@
 FROM openms/contrib
 
+LABEL software="OpenMS lib"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 WORKDIR /
 RUN git clone --depth 1 https://github.com/OpenMS/OpenMS.git -b nightly
 RUN mkdir openms-build

--- a/library/Dockerfile-qt5
+++ b/library/Dockerfile-qt5
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/feature/qt5/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 WORKDIR /
 RUN git clone https://github.com/OpenMS/OpenMS.git && cd /OpenMS && git checkout feature/qt5 && rm -rf .git share/OpenMS/examples/
 

--- a/library/Dockerfile-qt5
+++ b/library/Dockerfile-qt5
@@ -1,5 +1,13 @@
 FROM openms/contrib:qt5-v2.0
 
+LABEL software="OpenMS lib"
+LABEL software.version="feature/qt5"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/feature/qt5/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 WORKDIR /
 RUN git clone https://github.com/OpenMS/OpenMS.git && cd /OpenMS && git checkout feature/qt5 && rm -rf .git share/OpenMS/examples/
 

--- a/multistage/Dockerfile
+++ b/multistage/Dockerfile
@@ -83,4 +83,9 @@ RUN apt-get autoremove -y && \
 WORKDIR /
 ENV PATH="/OpenMS/bin/:${PATH}"
 ENV LD_LIBRARY_PATH="/OpenMS/lib/:${LD_LIBRARY_PATH}"
+ENV OPENMS_DATA_PATH /OpenMS/share/OpenMS
 
+RUN useradd -u 1001 -U -d /home/OpenMSuser -m -s /bin/bash OpenMSuser
+USER OpenMSuser
+ENV HOME /home/OpenMSuser
+WORKDIR /home/OpenMSuser

--- a/multistage/Dockerfile
+++ b/multistage/Dockerfile
@@ -7,10 +7,12 @@ RUN apt-get -y update
 RUN apt-get install -y --no-install-recommends --no-install-suggests binutils
 
 RUN for l in lib/*.so; do strip --strip-all $l; done
+#RUN strip --strip-all lib/libOpenMS.so
 #RUN strip --strip-all lib/libOpenSwathAlgo.so
 #RUN strip --strip-all lib/libSuperHirn.so
 
-RUN make TOPP && make UTILS && rm -rf src doc CMakeFiles 
+RUN make TOPP && make UTILS  
+#RUN make install
 
 FROM ubuntu:14.04
 ENV DEBIAN_FRONTEND noninteractive
@@ -36,27 +38,49 @@ COPY --from=library /OpenMS/share/OpenMS/MAPPING /OpenMS/share/OpenMS/MAPPING
 COPY --from=library /OpenMS/share/OpenMS/SCHEMAS /OpenMS/share/OpenMS/SCHEMAS
 COPY --from=library /OpenMS/share/OpenMS/XSL /OpenMS/share/OpenMS/XSL
 COPY --from=library /OpenMS/share/OpenMS/SCRIPTS /OpenMS/share/OpenMS/SCRIPTS
-COPY --from=library /openms-build/bin .
-COPY --from=library /openms-build/lib .
+COPY --from=library /openms-build/bin /OpenMS/bin
+COPY --from=library /openms-build/lib /OpenMS/lib
+
+#TODO eval if this is considerably slimmer than apt-get install as used below - 435MB vs. 559MB
+
+#COPY --from=library /contrib-build/lib/*.la /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libQtNetwork.so* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libQtCore.so* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libboost* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libxerces* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libglpk* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libgomp* /usr/lib/
+#COPY --from=library /usr/lib/libsvm* /usr/lib/
+#COPY --from=library /lib/x86_64-linux-gnu/libglib* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libicuuc* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libicui18n* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libcolamd* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libamd* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libltdl* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libgmp* /usr/lib/
+#COPY --from=library /usr/lib/x86_64-linux-gnu/libicudata* /usr/lib/
 
 RUN apt-get -y update
 RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev \
-								libglpk-dev \ 
-								libzip-dev \
-                                                                zlib1g-dev \
-								libxerces-c-dev \
-								libbz2-dev
+								      libglpk-dev \
+								      libzip-dev \
+								      zlib1g-dev \
+							              libxerces-c-dev \
+                                                                     libbz2-dev
 RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.54-dev \
                                                                      libboost-iostreams1.54-dev \
                                                                      libboost-regex1.54-dev \
                                                                      libboost-math1.54-dev \
                                                                      libboost-random1.54-dev
-RUN apt-get install -y --no-install-recommends --no-install-suggests libqt4-dev \
-								libqt4-opengl-dev \
-								libqt4-svg \
-								libqtwebkit-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libqtcore4 \
+								      libqt4-network
+RUN apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/lib/{cache,log}
 
+#example input for kicking tires
+#COPY --from=library /OpenMS/share/OpenMS/examples /OpenMS/share/OpenMS/examples
 
 WORKDIR /
-ENV PATH="/openms-build/bin/:${PATH}"
+ENV PATH="/OpenMS/bin/:${PATH}"
+ENV LD_LIBRARY_PATH="/OpenMS/lib/:${LD_LIBRARY_PATH}"
 

--- a/multistage/Dockerfile
+++ b/multistage/Dockerfile
@@ -1,0 +1,62 @@
+FROM openms/library as library
+ENV DEBIAN_FRONTEND noninteractive
+
+WORKDIR /openms-build
+
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests binutils
+
+RUN for l in lib/*.so; do strip --strip-all $l; done
+#RUN strip --strip-all lib/libOpenSwathAlgo.so
+#RUN strip --strip-all lib/libSuperHirn.so
+
+RUN make TOPP && make UTILS && rm -rf src doc CMakeFiles 
+
+FROM ubuntu:14.04
+ENV DEBIAN_FRONTEND noninteractive
+
+LABEL software="OpenMS executables"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
+LABEL base.image="ubuntu:14.04"
+
+RUN mkdir /OpenMS
+WORKDIR /OpenMS
+
+COPY --from=library /OpenMS/AUTHORS .
+COPY --from=library /OpenMS/CHANGELOG .
+COPY --from=library /OpenMS/LICENSE .
+COPY --from=library /OpenMS/README .
+COPY --from=library /OpenMS/share/OpenMS/CHEMISTRY /OpenMS/share/OpenMS/CHEMISTRY
+COPY --from=library /OpenMS/share/OpenMS/CV /OpenMS/share/OpenMS/CV
+COPY --from=library /OpenMS/share/OpenMS/MAPPING /OpenMS/share/OpenMS/MAPPING
+COPY --from=library /OpenMS/share/OpenMS/SCHEMAS /OpenMS/share/OpenMS/SCHEMAS
+COPY --from=library /OpenMS/share/OpenMS/XSL /OpenMS/share/OpenMS/XSL
+COPY --from=library /OpenMS/share/OpenMS/SCRIPTS /OpenMS/share/OpenMS/SCRIPTS
+COPY --from=library /openms-build/bin .
+COPY --from=library /openms-build/lib .
+
+RUN apt-get -y update
+RUN apt-get install -y --no-install-recommends --no-install-suggests libsvm-dev \
+								libglpk-dev \ 
+								libzip-dev \
+                                                                zlib1g-dev \
+								libxerces-c-dev \
+								libbz2-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libboost-date-time1.54-dev \
+                                                                     libboost-iostreams1.54-dev \
+                                                                     libboost-regex1.54-dev \
+                                                                     libboost-math1.54-dev \
+                                                                     libboost-random1.54-dev
+RUN apt-get install -y --no-install-recommends --no-install-suggests libqt4-dev \
+								libqt4-opengl-dev \
+								libqt4-svg \
+								libqtwebkit-dev
+
+
+WORKDIR /
+ENV PATH="/openms-build/bin/:${PATH}"
+

--- a/pyOpenMS/Dockerfile
+++ b/pyOpenMS/Dockerfile
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 WORKDIR /openms-build
 
 RUN apt-get update -y && apt-get install -y python-pip python-dev python-numpy

--- a/pyOpenMS/Dockerfile
+++ b/pyOpenMS/Dockerfile
@@ -1,5 +1,13 @@
 FROM openms/library
 
+LABEL software="pyOpenMS"
+LABEL software.version="develop"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/OpenMS/develop/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 WORKDIR /openms-build
 
 RUN apt-get update -y && apt-get install -y python-pip python-dev python-numpy

--- a/travis/Dockerfile-qt5-travis
+++ b/travis/Dockerfile-qt5-travis
@@ -8,6 +8,8 @@ LABEL tags="proteomics, mass spectrometry"
 LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
 LABEL base.image="ubuntu:14.04"
 
+ENV DEBIAN_FRONTEND noninteractive
+
 WORKDIR /
 ADD . /OpenMS
 RUN cd /OpenMS

--- a/travis/Dockerfile-qt5-travis
+++ b/travis/Dockerfile-qt5-travis
@@ -1,5 +1,13 @@
 FROM openms/contrib:qt5-v2.0
 
+LABEL software="OpenMS qt5 travis"
+LABEL software.version="qt5-v2.0"
+LABEL website="https://www.OpenMS.de"
+LABEL documentation="https://www.OpenMS.de/documentation/"
+LABEL tags="proteomics, mass spectrometry"
+LABEL license="https://raw.githubusercontent.com/OpenMS/contrib/master/License.txt"
+LABEL base.image="ubuntu:14.04"
+
 WORKDIR /
 ADD . /OpenMS
 RUN cd /OpenMS


### PR DESCRIPTION
Adding a slimmer built using multistage docker build feature and one that has 3rd party binaries included.
Introducing labels and ('end') user change.
The folder/build name 'multistage' is probably subject to change, something along the lines of optimised. But I wanted to put the development so far out there, have some conversation as this PR evolves.