### PR TITLE
[ADD] Dockerfile for building OpenMS on Arch Linux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "archlinux_build"]
+	path = archlinux_build
+	url = https://github.com/lukaszimmermann/docker_openms_archlinux_build.git
+	branch = master


### PR DESCRIPTION
Adds a dockerfile that builds OpenMS (TOPP, UTILS, GUI) on Arch Linux base images. It does this by writting the PKGBUILD file and then creating the package with makepkg. The content of the Dockerfile is synchronized with the  package on AUR:

https://aur.archlinux.org/packages/openms/#news

The repo with the Dockerfile is currently included as a submodule (because there is a configured automated build on Docker Hub), but the repo could also be merged into this one. 
