### PR TITLE
Use the correct THIRDPARTY directory

### DIFF
--- a/executables/Dockerfile
+++ b/executables/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /OpenMS
 RUN mkdir /thirdparty && \
     git submodule update --init THIRDPARTY && \
     cp -r THIRDPARTY/All/* /thirdparty && \
-    cp -r THIRDPARTY/Linux/64bit/* /thirdparty
+    cp -r THIRDPARTY/Linux/x86_64/* /thirdparty
 ENV PATH="/thirdparty/LuciPHOr2:/thirdparty/MSGFPlus:/thirdparty/Sirius:/thirdparty/ThermoRawFileParser:/thirdparty/Comet:/thirdparty/Fido:/thirdparty/MaRaCluster:/thirdparty/Percolator:/thirdparty/SpectraST:/thirdparty/XTandem:/thirdparty/Sage:${PATH}"
 
 WORKDIR /openms-build


### PR DESCRIPTION
The THIRDPARTY repository directory structure was changed.  This commit updates the dockerfile so it matches the changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the source directory for third-party Linux binaries included in the build process. No changes to application features or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->